### PR TITLE
rescue LoadError, specifically, in display_width

### DIFF
--- a/lib/oyster/specification.rb
+++ b/lib/oyster/specification.rb
@@ -134,7 +134,7 @@ module Oyster
                    x = Curses.cols
                    Curses.close_screen
                    x
-                 rescue
+                 rescue LoadError
                    HELP_WIDTH
                  end
       @width - HELP_INDENT


### PR DESCRIPTION
the LoadError was passing through, instead of defaulting as expected, when I didn't have curses installed.
